### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A `section` node has a title and a type attribute. The title can be whatever you
 
 #####List
 
-The simplest section type. It has `item` child nodes. The `item` nodes have no childen and their content becomes the bulleted text.
+The simplest section type. It has `item` child nodes. The `item` nodes have no children and their content becomes the bulleted text.
 
 ````xml
 <section title="skills" type="list">


### PR DESCRIPTION
@nickswalker, I've corrected a typographical error in the documentation of the [neueresume](https://github.com/nickswalker/neueresume) project. Specifically, I've changed childen to children. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
